### PR TITLE
add Normalizing Kalman Filters paper in applications section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -194,9 +194,9 @@ A list of awesome resources for understanding and applying normalizing flows (NF
 5. Oct 13, 2020 - [Targeted free energy estimation via learned mappings](https://aip.scitation.org/doi/10.1063/5.0018903)
    > Normalizing flows used to estimate free energy differences.
 
-6. Dec 6, 2020 - [Normalizing Kalman Filters for Multivariate Time Series Analysis](https://proceedings.neurips.cc/paper/2020/file/1f47cef5e38c952f94c5d61726027439-Paper.pdf)
+6. Dec 6, 2020 - [Normalizing Kalman Filters for Multivariate Time Series Analysis](https://proceedings.neurips.cc/paper/2020/hash/1f47cef5e38c952f94c5d61726027439-Abstract.html)
 
-   > Augments state space models with normalizing flows & thereby mitigate imprecisions stemming from idealized assumptions.
+   > Augments state space models with normalizing flows and thereby mitigates imprecisions stemming from idealized assumptions. Aimed at forecasting real world data and handling varying levels of missing data. (Also available at [Amazon Science](https://amazon.science/publications/normalizing-kalman-filters-for-multivariate-time-series-analysis))
 
 <br>
 

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,10 @@ A list of awesome resources for understanding and applying normalizing flows (NF
 5. Oct 13, 2020 - [Targeted free energy estimation via learned mappings](https://aip.scitation.org/doi/10.1063/5.0018903)
    > Normalizing flows used to estimate free energy differences.
 
+6. Dec 6, 2020 - [Normalizing Kalman Filters for Multivariate Time Series Analysis](https://proceedings.neurips.cc/paper/2020/file/1f47cef5e38c952f94c5d61726027439-Paper.pdf)
+
+   > Augments state space models with normalizing flows & thereby mitigate imprecisions stemming from idealized assumptions.
+
 <br>
 
 ## 📺 Videos


### PR DESCRIPTION
Hi @janosh 

This is a very interesting NeurIPS 2020 paper from Amazon. I think it belongs in the applications section. 

Interestingly the paper is not available on https://arxiv.org/ and there is no date :( 

So for now I have put "Dec 6, 2020" because 6th Dec was the first day for NeurIPS 2020

Regards & thanks
Kapil

