### PR TITLE
Update the name of `ICNF.jl`

### DIFF
--- a/data/packages.yml
+++ b/data/packages.yml
@@ -103,11 +103,11 @@
 
 - title: ContinuousNormalizingFlows.jl
   date: 2021-11-07
-  date_added: 2023-05-31
+  date_added: 2022-12-05
   last_updated: 2023-05-31
   url: https://github.com/impICNF/ContinuousNormalizingFlows.jl
   authors: Hossein Pourbozorg
   authors_url: https://github.com/prbzrg
   description: Implementations of Infinitesimal Continuous Normalizing Flows Algorithms in Julia.
   lang: Julia
-  docs: https://impicnf.github.io/ContinuousNormalizingFlows.jl/
+  docs: https://impicnf.github.io/ContinuousNormalizingFlows.jl

--- a/data/packages.yml
+++ b/data/packages.yml
@@ -100,3 +100,14 @@
   lang: PyTorch
   description: The library provides most of the common normalizing flow architectures. It also includes stochastic layers, flows on tori and spheres, and other tools that are particularly useful for applications to the physical sciences.
   date_added: 2022-12-21
+
+- title: ContinuousNormalizingFlows.jl
+  date: 2021-11-07
+  date_added: 2023-05-31
+  last_updated: 2023-05-31
+  url: https://github.com/impICNF/ContinuousNormalizingFlows.jl
+  authors: Hossein Pourbozorg
+  authors_url: https://github.com/prbzrg
+  description: Implementations of Infinitesimal Continuous Normalizing Flows Algorithms in Julia.
+  lang: Julia
+  docs: https://impicnf.github.io/ContinuousNormalizingFlows.jl/

--- a/data/repos.yml
+++ b/data/repos.yml
@@ -150,14 +150,3 @@
   lang: TensorFlow
   description: |
     Implementation of normalizing flows (Planar Flow, Radial Flow, Real NVP, Masked Autoregressive Flow (MAF), Inverse Autoregressive Flow (IAF), Neural Spline Flow) in TensorFlow 2 including a small tutorial.
-
-- title: ICNF.jl
-  date: 2021-11-10
-  date_added: 2022-12-05
-  last_updated: 2022-12-05
-  url: https://github.com/impICNF/ICNF.jl
-  docs: https://impicnf.github.io/ICNF.jl/dev
-  authors: Hossein Pourbozorg
-  authors_url: https://github.com/prbzrg
-  lang: Julia
-  description: Implementations of Infinitesimal Continuous Normalizing Flows in Julia.

--- a/readme.md
+++ b/readme.md
@@ -372,6 +372,11 @@ Zuko is used in [LAMPE](https://github.com/francois-rozet/lampe) to enable Likel
 
 ### <img src="assets/julia.svg" alt="Julia" height="20px"> &nbsp;Julia Packages
 
+1. 2021-11-07 - [ContinuousNormalizingFlows.jl](https://github.com/impICNF/ContinuousNormalizingFlows.jl) by [Hossein Pourbozorg](https://github.com/prbzrg)
+&ensp;
+<img src="https://img.shields.io/github/stars/impICNF/ContinuousNormalizingFlows.jl" alt="GitHub repo stars" valign="middle" /><br>
+   Implementations of Infinitesimal Continuous Normalizing Flows Algorithms in Julia. [[Docs](https://impicnf.github.io/ContinuousNormalizingFlows.jl/)]
+
 1. 2020-02-07 - [InvertibleNetworks.jl](https://github.com/slimgroup/InvertibleNetworks.jl) by [SLIM](https://slim.gatech.edu)
 &ensp;
 <img src="https://img.shields.io/github/stars/slimgroup/InvertibleNetworks.jl" alt="GitHub repo stars" valign="middle" /><br>
@@ -462,15 +467,6 @@ Implements flows such as MAF, RealNVP and NICE.
 
 1. 2020-06-12 - [Neural Transport](https://pyro.ai/numpyro/examples/neutra) by [numpyro](https://num.pyro.ai)<br>
    Features an example of how Normalizing flows can be used to get more robust posteriors from Monte Carlo methods. Uses the `numpyro` library which is a PPL with JAX as the backend. The NF implementations include the basic ones like IAF and BNAF.
-
-<br>
-
-### <img src="assets/julia.svg" alt="Julia" height="20px"> &nbsp;Julia Repos
-
-1. 2021-11-10 - [ICNF.jl](https://github.com/impICNF/ICNF.jl) by [Hossein Pourbozorg](https://github.com/prbzrg)
-&ensp;
-<img src="https://img.shields.io/github/stars/impICNF/ICNF.jl" alt="GitHub repo stars" valign="middle" /><br>
-   Implementations of Infinitesimal Continuous Normalizing Flows in Julia. [[Docs](https://impicnf.github.io/ICNF.jl/dev)]
 
 <br>
 


### PR DESCRIPTION
I just changed the name of the package `ICNF.jl` to `ContinuousNormalizingFlows.jl`, so I updated it here. Also, it must be in packages section.